### PR TITLE
Add "Infrastructure as code" and remove the use of keys

### DIFF
--- a/_data/jekyll-vsts-azure-nav.json
+++ b/_data/jekyll-vsts-azure-nav.json
@@ -49,7 +49,7 @@
     "enabled": true,
     "title": "Infrastructure as code",
     "description":
-      "In this article, I give you the VSTS pipeline code that you can import.",
+      "In this article, I give you the YAML code that you can use to automatically create the build definition by adding a `.vsts-ci.yml` file to your Jekyll website. This can replace \"Part 1: The VSTS Build\".",
     "url":
       "/en/articles/2018/07/23/how-to-deploy-and-host-a-jekyll-website-in-azure-blob-storage-using-a-vsts-continuous-deployment-pipeline-infrastructure-as-code/"
   },

--- a/_data/jekyll-vsts-azure-nav.json
+++ b/_data/jekyll-vsts-azure-nav.json
@@ -46,6 +46,15 @@
   },
   {
     "index": 5,
+    "enabled": true,
+    "title": "Infrastructure as code",
+    "description":
+      "In this article, I give you the VSTS pipeline code that you can import.",
+    "url":
+      "/en/articles/2018/07/23/how-to-deploy-and-host-a-jekyll-website-in-azure-blob-storage-using-a-vsts-continuous-deployment-pipeline-infrastructure-as-code/"
+  },
+  {
+    "index": 6,
     "enabled": false,
     "hidden": true,
     "title": "Conclusion",

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -80,7 +80,7 @@
 <script src="{{ "/js/forevolve-blog.min.js" | prepend: site.baseurl }}"></script>
 
 <!-- Prism JS code coloring -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/prism.min.js" integrity="sha256-Zb9yKJ/cfs+jG/zIOFL0QEuXr2CDKF7FR5YBJY3No+c=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.15.0/prism.min.js" integrity="sha256-jc6y1s/Y+F+78EgCT/lI2lyU7ys+PFYrRSJ6q8/R8+o=" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/components/prism-csharp.js" integrity="sha256-t5SXqeRw0r4NogAmxKit1gE92EswJYGns/FRQCXIPao=" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/components/prism-powershell.js" integrity="sha256-ezsL6j/QS1NHMHoDmsZzLQRxIUyql45FGYigDMS/T6E=" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/components/prism-bash.min.js" integrity="sha256-Cpwt90TIzSA/DB4pWWhjvGMLFzqRuClV20inTWKgJ2w=" crossorigin="anonymous"></script>
@@ -95,6 +95,7 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/plugins/data-uri-highlight/prism-data-uri-highlight.min.js" integrity="sha256-U+CLEiyzlOJhTnE33bjNVVdSdORPYfDfQ0qZjU/qpKc=" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/components/prism-markdown.min.js" integrity="sha256-IQow2xuq3uimzcQ7pu3eGfgBtlP7zlRta7+e55oCAM4=" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/components/prism-json.min.js" integrity="sha256-FHdwSoXfoVWRO3wrjL83q5cqSEOKEvCRZlABqc03O2E=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.15.0/components/prism-yaml.min.js" integrity="sha256-pxsoS7PqPuy6D5T0Dq2PEXKJ5SRlIkdG8hpoMxQ0YlM=" crossorigin="anonymous"></script>
 
 {% comment %}Amazon oneTag{% endcomment %}
 <script src="//z-na.amazon-adsystem.com/widgets/onejs?MarketPlace=US&adInstanceId=e72533ad-0cba-4d77-b234-484f9112ff5d"></script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -57,6 +57,11 @@
     <!-- Pygments Github CSS -->
     <link rel="stylesheet" href="{{ "/css/syntax.css" | prepend: site.baseurl }}">
 
+    <!-- Prism.js CSS -->
+    {% comment %} <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.15.0/themes/prism.min.css" integrity="sha256-N1K43s+8twRa+tzzoF3V8EgssdDiZ6kd9r8Rfgg8kZU=" crossorigin="anonymous" /> {% endcomment %}
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.15.0/themes/prism-coy.min.css" integrity="sha256-pBLOnOQq8E9POmDOv09xSKrPQYI6feWEhyTgl1Q8Bwk=" crossorigin="anonymous" />
+    {% comment %} <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.15.0/themes/prism-tomorrow.min.css" integrity="sha256-4S9ufRr1EqaUFFeM9/52GH68Hs1Sbvx8eFXBWpl8zPI=" crossorigin="anonymous" /> {% endcomment %}
+
     <!-- Custom Fonts -->
     <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" rel="stylesheet" type="text/css">
     <link href='//fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic' rel='stylesheet' type='text/css'>

--- a/_includes/jekyll-vsts-azure/next.md
+++ b/_includes/jekyll-vsts-azure/next.md
@@ -1,7 +1,7 @@
 {% assign nextIndex = include.nextIndex %}
 {% assign nextArticle = site.data.jekyll-vsts-azure-nav[nextIndex] %}
 
-## Next step
+{% if include.hideHeading %}{% else %}## Next step{% endif %}
 
 {% if include.continueText %}{{ include.continueText }}{% else %}It is now time to move to the next article:{% endif %}{% if nextArticle.enabled %}
 [{{ nextArticle.title }}]({{ nextArticle.url }}).

--- a/_includes/jekyll-vsts-azure/yaml-build-definition.md
+++ b/_includes/jekyll-vsts-azure/yaml-build-definition.md
@@ -1,0 +1,28 @@
+```yaml
+queue:
+  name: Hosted VS2017
+  condition: succeeded()
+steps:
+- task: UseRubyVersion@0
+  displayName: Use Ruby >= 2.4
+
+- script: 'gem install jekyll bundler'
+  displayName: Install Jekyll and bundler
+
+- script: 'bundle install'
+  displayName: Install Gems
+
+- script: 'bundle exec jekyll build'
+  displayName: Build
+
+- task: CopyFiles@2
+  displayName: Copy "_site" to staging directory
+  inputs:
+    SourceFolder: '_site'
+    TargetFolder: '$(build.artifactstagingdirectory)'
+
+- task: PublishBuildArtifacts@1
+  displayName: Publish Artifact: _site
+  inputs:
+    ArtifactName: '_site'
+```

--- a/_includes/updates.html
+++ b/_includes/updates.html
@@ -1,0 +1,10 @@
+{% if page.updates %}
+<aside class="update-list">
+    <h2 id="updates">Updates</h2>
+    <ul>
+    {% for update in page.updates %}
+        <li>{{ update.date }}: {{ update.description }}</li>
+    {% endfor %}
+    </ul>
+</aside>
+{% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -67,6 +67,8 @@ layout: default
 
 				<article>{{ content }}</article>
 
+                {% include updates.html %}
+
                 {% if totalCount > 0 %}
                     <hr>
                     <nav>

--- a/_posts/en/2018-07-10-how-to-deploy-and-host-a-jekyll-website-in-azure-blob-storage-using-a-vsts-continuous-deployment-pipeline-part-1.md
+++ b/_posts/en/2018-07-10-how-to-deploy-and-host-a-jekyll-website-in-azure-blob-storage-using-a-vsts-continuous-deployment-pipeline-part-1.md
@@ -19,6 +19,8 @@ technology-relative-level:
 - { name: DevOps, level: Beginners }
 - { name: Jekyll, level: Intermediate }
 - { name: Git, level: Intermediate }
+updates:
+- { date: 2018-07-23, description: "Add Infrastructure as code" }
 ---
 
 In this article series, we will create a continuous deployment (CD) pipeline using Visual Studio Team Services (VSTS) to deploy a Jekyll website to Microsoft Azure.
@@ -205,5 +207,11 @@ Once pushed, VSTS should contain your code (after you refresh the page).
         </figcaption>
     </figure>
 </aside>
+
+## Infrastructure as code
+
+{% assign iacArticle = site.data.jekyll-vsts-azure-nav[5] %}
+
+If you want to automatically create the build definition when you push your code, you can jump to [{{ iacArticle.title }}]({{ iacArticle.url }}) and use the provided YAML code.
 
 {% include jekyll-vsts-azure/next.md nextIndex=1 %}

--- a/_posts/en/2018-07-10-how-to-deploy-and-host-a-jekyll-website-in-azure-blob-storage-using-a-vsts-continuous-deployment-pipeline-part-2.md
+++ b/_posts/en/2018-07-10-how-to-deploy-and-host-a-jekyll-website-in-azure-blob-storage-using-a-vsts-continuous-deployment-pipeline-part-2.md
@@ -19,6 +19,8 @@ technology-relative-level:
 - { name: DevOps, level: Beginners }
 - { name: Jekyll, level: Intermediate }
 - { name: Git, level: Intermediate }
+updates:
+- { date: 2018-07-23, description: "Add Infrastructure as code" }
 ---
 
 Now the fun begins, we have a website to deploy, a VSTS project and a Git repository.
@@ -190,5 +192,15 @@ Then navigate to the `Triggers` tab and check `Enable continuous integration`.
 Save the build definition, and voilà, each `push` will now queue a new build!
 
 > You can push some changes if you want to try it out!
+
+## Infrastructure as code
+
+{% assign iacArticle = site.data.jekyll-vsts-azure-nav[5] %}
+
+If you want to automatically create the build definition when you push your code instead of manually following all the steps (and at the same time automating the build process creation), you can jump to [{{ iacArticle.title }}]({{ iacArticle.url }}) and use the provided YAML code.
+
+Alternatively, if you know what I am talking about, here is the code:
+
+{% include jekyll-vsts-azure/yaml-build-definition.md %}
 
 {% include jekyll-vsts-azure/next.md nextIndex=2 %}

--- a/_posts/en/2018-07-10-how-to-deploy-and-host-a-jekyll-website-in-azure-blob-storage-using-a-vsts-continuous-deployment-pipeline-part-4.md
+++ b/_posts/en/2018-07-10-how-to-deploy-and-host-a-jekyll-website-in-azure-blob-storage-using-a-vsts-continuous-deployment-pipeline-part-4.md
@@ -253,3 +253,5 @@ To see this happen:
 ---
 
 {% include jekyll-vsts-azure/next.md nextIndex=4 %}
+
+{% include jekyll-vsts-azure/next.md nextIndex=5 continueText="Until I publish the CDN article, you can move to: " hideHeading=true %}

--- a/_posts/en/2018-07-10-how-to-deploy-and-host-a-jekyll-website-in-azure-blob-storage-using-a-vsts-continuous-deployment-pipeline-part-4.md
+++ b/_posts/en/2018-07-10-how-to-deploy-and-host-a-jekyll-website-in-azure-blob-storage-using-a-vsts-continuous-deployment-pipeline-part-4.md
@@ -19,6 +19,8 @@ technology-relative-level:
 - { name: DevOps, level: Beginners }
 - { name: Jekyll, level: Intermediate }
 - { name: Git, level: Intermediate }
+updates:
+- { date: 2018-07-23, description: "Remove references to \"storage key\". "}
 ---
 
 Now that we have a Blob Storage container set up for static website delivery, we need to deploy our Jekyll website there.<!--more-->
@@ -116,7 +118,7 @@ To do this, select the first Azure CLI task.
 - Display name: `Delete old files`
 - Azure subscription: `Jekyll on Azure resource group` (choose the one you just created)
 - Script location: `Inline Scripts`
-- Inline Script: `az storage blob delete-batch --source $(containerName) --account-name $(storageAccount) --account-key $(storageKey) --output table`
+- Inline Script: `az storage blob delete-batch --source $(containerName) --account-name $(storageAccount) --output table`
 - Working Directory: select the artifact name. Mine is `$(System.DefaultWorkingDirectory)/_JekyllOnAzure-CI`.
   <br><small><strong>Do not</strong> select the `_site` subdirectory.</small>
 
@@ -135,7 +137,7 @@ Select the second Azure CLI task and do the same thing.
 - Script location: `Inline Scripts`
 - Inline Script:
   ```
-  az storage blob upload-batch --source _site --destination $(containerName) --account-name $(storageAccount) --account-key $(storageKey) --output table --no-progress
+  az storage blob upload-batch --source _site --destination $(containerName) --account-name $(storageAccount) --output table --no-progress
   ```
 - Working Directory: select the artifact name. Mine is `$(System.DefaultWorkingDirectory)/_JekyllOnAzure-CI`.
   <br><small><strong>Do not</strong> select the `_site` subdirectory.</small>
@@ -157,21 +159,13 @@ Navigate to the `Variables` tab and add the following variables:
 
 - Set the `containerName` value to `$web`
 - Set the `storageAccount` value to the name of your storage account. Mine was `jekyllonazure`.
-- Set the `storageKey` value to one of the Azure Storage Access keys (see below). Then protect this value by clicking the `lock` icon.
 
-![Lock the VSTS variable secret values](//cdn.forevolve.com/blog/images/2018/VSTS-lock-variable-values.png)
+![Lock the VSTS variable secret values](//cdn.forevolve.com/blog/images/2018/VSTS-lock-variable-values-v2.png)
 
 > How does this work? The value of the `containerName` variable will replace `$(containerName)` in the Azure CLI scripts.
 > So it will execute that command: `az storage blob upload-batch --source _site --destination $web [...]`
 >
 > You can use variables extensively in VSTS.
-
-### Find Azure Storage Keys
-
-From your Azure Storage Account, navigate to `Access keys` then copy one of the two keys.
-![Locate azure storage keys](//cdn.forevolve.com/blog/images/2018/Azure-storage-keys.png)
-
-> Note: I regenerated both keys so don't waste your time trying them, they don't work anymore.
 
 ## Save and test the deployment
 

--- a/_posts/en/2018-07-10-how-to-deploy-and-host-a-jekyll-website-in-azure-blob-storage-using-a-vsts-continuous-deployment-pipeline-part-4.md
+++ b/_posts/en/2018-07-10-how-to-deploy-and-host-a-jekyll-website-in-azure-blob-storage-using-a-vsts-continuous-deployment-pipeline-part-4.md
@@ -248,4 +248,4 @@ To see this happen:
 
 {% include jekyll-vsts-azure/next.md nextIndex=4 %}
 
-{% include jekyll-vsts-azure/next.md nextIndex=5 continueText="Until I publish the CDN article, you can move to: " hideHeading=true %}
+{% include jekyll-vsts-azure/next.md nextIndex=5 continueText="Until I publish the CDN article, you can move to (if not already read): " hideHeading=true %}

--- a/_posts/en/2018-07-23-how-to-deploy-and-host-a-jekyll-website-in-azure-blob-storage-using-a-vsts-continuous-deployment-pipeline-infrastructure-as-code.md
+++ b/_posts/en/2018-07-23-how-to-deploy-and-host-a-jekyll-website-in-azure-blob-storage-using-a-vsts-continuous-deployment-pipeline-infrastructure-as-code.md
@@ -1,0 +1,49 @@
+---
+title:  "How to deploy and host a Jekyll website in Azure blob storage using a VSTS continuous deployment pipeline"
+subtitle: "Infrastructure as code"
+date:     2018-07-23 00:00:04 -0500
+post-img: "//cdn.forevolve.com/blog/images/articles-header/2018-07-00-jekyll-vsts-azure-v3.jpg"
+unsplash-credit: Photo by Jilbert Ebrahimi on Unsplash
+lang: en
+categories: en/articles
+tags: 
+- Azure
+- VSTS
+- DevOps
+- Jekyll
+- FromCodeToCloud
+# proficiency-level: Novice
+technology-relative-level:
+- { name: VSTS, level: Beginners }
+- { name: DevOps, level: Beginners }
+---
+
+I've got a good idea from a reader, and I decided to move forward with it: Infrastructure as code.
+
+In this "article" (if I can name it that), I give you the VSTS pipeline code that you can import into your VSTS instance to recreate the pipeline without reading the whole thing (in case you don't want to).
+
+The cool thing about the "infrastructure as code" mindset is the fact that you can manage your infrastructure code as if it was any other code. So you can use Git, VS Code or any other coding tool that you like. It can also facilitate collaboration, and it does facilitate reusability. Deploying an environment become as easy as running the code!
+
+Azure also support the deployment of infrastructure as code. You can create Azure resources using ARM templates. Unfortunately, at the time of this writing, Azure does not support "Static Website (preview)" in the ARM, so I can't give you that code.<!--more-->
+
+{% include jekyll-vsts-azure/toc.md currentIndex=5 %}
+
+## The VSTS pipeline
+
+This is the first version of the pipeline, before we connect the CDN to it:
+
+```
+TODO
+```
+
+## The VSTS pipeline (including the CDN)
+
+This is the second version of the pipeline, after we connected the CDN to it:
+
+```
+TODO
+```
+
+## The end
+
+Enjoy these little pieces of code and happy coding!

--- a/_posts/en/2018-07-23-how-to-deploy-and-host-a-jekyll-website-in-azure-blob-storage-using-a-vsts-continuous-deployment-pipeline-infrastructure-as-code.md
+++ b/_posts/en/2018-07-23-how-to-deploy-and-host-a-jekyll-website-in-azure-blob-storage-using-a-vsts-continuous-deployment-pipeline-infrastructure-as-code.md
@@ -20,30 +20,31 @@ technology-relative-level:
 
 I've got a good idea from a reader, and I decided to move forward with it: Infrastructure as code.
 
-In this "article" (if I can name it that), I give you the VSTS pipeline code that you can import into your VSTS instance to recreate the pipeline without reading the whole thing (in case you don't want to).
+In this "article" (if I can name it that), I give you the YAML code that you can use to automatically create the build definition by adding a `.vsts-ci.yml` file to your Jekyll website.
 
-The cool thing about the "infrastructure as code" mindset is the fact that you can manage your infrastructure code as if it was any other code. So you can use Git, VS Code or any other coding tool that you like. It can also facilitate collaboration, and it does facilitate reusability. Deploying an environment become as easy as running the code!
+The cool thing about the "infrastructure as code" mindset is the fact that you can manage your infrastructure as if it was any other code. So you can use Git, VS Code or any other coding tool you like. It can also facilitate collaboration, and it does facilitate reusability (and in our case: sharing).
 
-Azure also support the deployment of infrastructure as code. You can create Azure resources using ARM templates. Unfortunately, at the time of this writing, Azure does not support "Static Website (preview)" in the ARM, so I can't give you that code.<!--more-->
+Unfortunately, only the build definition can be shared this way right now.
+However, Azure does support the deployment of infrastructure as code.
+You can create Azure resources using ARM templates.
+Sadly, at the time of this writing, Azure does not support "Static Website (preview)" in the ARM, so I can't give you that code.<!--more-->
 
 {% include jekyll-vsts-azure/toc.md currentIndex=5 %}
 
 ## The VSTS pipeline
 
-This is the first version of the pipeline, before we connect the CDN to it:
+Before going further, please make sure you activated the YAML preview feature.
 
-```
-TODO
-```
+Feel free to follow that link for more information about [How to use YAML builds](https://docs.microsoft.com/en-us/vsts/pipelines/build/yaml?view=vsts).
 
-## The VSTS pipeline (including the CDN)
+### Build definition
 
-This is the second version of the pipeline, after we connected the CDN to it:
+{% include jekyll-vsts-azure/yaml-build-definition.md %}
 
-```
-TODO
-```
+### Release definition
 
-## The end
+{% assign releaseArticle = site.data.jekyll-vsts-azure-nav[3] %}
 
-Enjoy these little pieces of code and happy coding!
+You cannot use YAML for releases, and you'd need to apply some manual changes to the exported JSON, so I decided not to include it here. You will have to build the release definition yourself by following the steps described in [{{ releaseArticle.title }}]({{ releaseArticle.url }})
+
+{% include jekyll-vsts-azure/next.md nextIndex=2 continueText="While I hope you enjoyed this little piece of code, now that the build definition is created (and automated), it is time to go back to the original series, to the article: " %}


### PR DESCRIPTION
Add "Infrastructure as code" to the article series "How to deploy and host a Jekyll website in Azure blob storage using a VSTS continuous deployment pipeline".
Remove the use of Azure Storage keys.
Add support for "updates"